### PR TITLE
New pydantic.ai versions obsoleted the api_key parameter

### DIFF
--- a/src/buildkite_demo_agent/osv_agent.py
+++ b/src/buildkite_demo_agent/osv_agent.py
@@ -57,7 +57,7 @@ class OSVAgent:
             self.osv_server = MCPServerSSE(f"{config.osv_server_url}/sse")
         
         # Create the model
-        model = AnthropicModel('claude-3-5-sonnet-20241022', api_key=api_key)
+        model = AnthropicModel('claude-3-5-sonnet-20241022')
         
         # Create the agent with OSV MCP tools
         self.agent = Agent(


### PR DESCRIPTION
Instead, pydantic just uses the environment variables